### PR TITLE
Simplify function

### DIFF
--- a/JetStream.lua
+++ b/JetStream.lua
@@ -9231,8 +9231,7 @@ for i,k in pairs(execute_function) do
         local mr = finale.FCMusicRegion()
         mr:SetCurrentSelection()
         function compare(compare_to)
-            local result = compare_values(k, compare_to)
-            return result
+            return compare_values(k, compare_to)
         end
 
         if mr:IsEmpty() ~= true then


### PR DESCRIPTION
In general, you don't need to assign a value, only to just return it. It's really only helpful if the variable name adds context. In this case, the name `result` doesn't, so there's no need to create the assignment.