### PR TITLE
Simplify default value

### DIFF
--- a/JetStream.lua
+++ b/JetStream.lua
@@ -16,7 +16,7 @@ init_region:SetCurrentSelection()
 
 function split(s, delimiter)
     result = {};
-    if s == nil then s = "" end
+    s = s or ""
     for match in (s..delimiter):gmatch("(.-)"..delimiter) do
         match = string.lower(match)
         if match ~= "" then


### PR DESCRIPTION
The standard pattern for creating a default value in Lua is:

```lua
item = item or "default"
```

instead of:

```lua
if item == nil then item = "default" end
```

This PR doesn't really impact much other than making something more idiomatic to Lua. The existing way of setting the default value is perfectly valid.